### PR TITLE
Add internal AGNTCY ADS deployment support for the demo environment

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -9,6 +9,10 @@
 #
 # Usage:
 #   export DOCKER_REGISTRY=your-registry.example.com/mbta
+#   export DEPLOY_INTERNAL_AGNTCY_ADS=true                    # optional, deploy official AGNTCY DIR chart in-cluster
+#   export AGNTCY_DIR_CHART_VERSION=v1.0.0                   # optional, default shown here for demo branch
+#   export AGNTCY_DIR_RELEASE_NAME=mbta-ads                  # optional, default shown here for demo branch
+#   export AGNTCY_DIR_NAMESPACE=mbta-ads                     # optional, default shown here for demo branch
 #   bash deploy.sh [build|push|apply|all]
 #
 # Build settings (optional):
@@ -30,6 +34,56 @@ RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
 info()  { echo -e "${GREEN}[INFO]${NC} $1"; }
 warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
 error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
+
+configmap_value() {
+  local key="$1"
+  awk -F': ' -v key="$key" '$1 == "  " key { print $2; exit }' "${SCRIPT_DIR}/k8s/configmap.yaml" | tr -d '"'
+}
+
+validate_ads_config() {
+  local federation_enabled ads_url ads_search_path
+  federation_enabled="$(configmap_value ENABLE_FEDERATION)"
+  ads_url="$(configmap_value AGNTCY_ADS_URL)"
+  ads_search_path="$(configmap_value AGNTCY_ADS_SEARCH_PATH)"
+
+  if [[ "${federation_enabled}" == "true" && -z "${ads_url}" ]]; then
+    warn "ENABLE_FEDERATION is true but AGNTCY_ADS_URL is empty in k8s/configmap.yaml."
+    warn "Internal ADS will not participate in federation until AGNTCY_ADS_URL is configured."
+  fi
+
+  if [[ -n "${ads_url}" && "${ads_search_path}" == "/v1/search" ]]; then
+    warn "The current MBTA registry adapter still uses legacy HTTP AGNTCY settings."
+    warn "Official AGNTCY DIR/ADS exposes gRPC on port 8888, so live ADS lookups still require a follow-up adapter update."
+  fi
+}
+
+deploy_internal_ads() {
+  if [[ "${DEPLOY_INTERNAL_AGNTCY_ADS:-false}" != "true" ]]; then
+    return 0
+  fi
+
+  if ! command -v helm >/dev/null 2>&1; then
+    error "helm is required when DEPLOY_INTERNAL_AGNTCY_ADS=true"
+  fi
+
+  local values_file release_name chart_version namespace
+  values_file="${AGNTCY_DIR_VALUES_FILE:-${SCRIPT_DIR}/k8s/agntcy-dir-values.yaml}"
+  release_name="${AGNTCY_DIR_RELEASE_NAME:-mbta-ads}"
+  chart_version="${AGNTCY_DIR_CHART_VERSION:-v1.0.0}"
+  namespace="${AGNTCY_DIR_NAMESPACE:-mbta-ads}"
+
+  if [[ ! -f "${values_file}" ]]; then
+    error "Internal ADS requested but values file not found at ${values_file}. Create it from k8s/agntcy-dir-values.example.yaml."
+  fi
+
+  info "Deploying internal AGNTCY DIR via Helm chart (${chart_version})..."
+  helm upgrade --install "${release_name}" \
+    oci://ghcr.io/agntcy/dir/helm-charts/dir \
+    --version "${chart_version}" \
+    --namespace "${namespace}" \
+    --create-namespace \
+    -f "${values_file}"
+}
 
 get_dockerhub_creds() {
   if [[ -n "${DOCKERHUB_USERNAME:-}" && -n "${DOCKERHUB_TOKEN:-}" ]]; then
@@ -159,10 +213,12 @@ apply() {
   fi
 
   # Apply non-templated manifests
+  validate_ads_config
   kubectl apply -f "${SCRIPT_DIR}/k8s/namespace.yaml"
   kubectl apply -f "${SCRIPT_DIR}/k8s/configmap.yaml"
   kubectl apply -f "${SCRIPT_DIR}/k8s/secrets.yaml"
   kubectl apply -f "${SCRIPT_DIR}/k8s/observability.yaml"
+  deploy_internal_ads
 
   # Replace image placeholders in manifests with actual registry
   info "Substituting image registry in manifests..."

--- a/k8s/agntcy-dir-values.example.yaml
+++ b/k8s/agntcy-dir-values.example.yaml
@@ -1,0 +1,43 @@
+fullnameOverride: mbta-ads
+
+postgresql:
+  enabled: true
+  auth:
+    username: dir
+    password: dir
+    database: dir
+
+zot:
+  enabled: true
+
+# Development-oriented example values for the official AGNTCY Directory chart.
+# Review these against the upstream chart version you deploy.
+config:
+  listen_address: "0.0.0.0:8888"
+  routing:
+    listen_address: "/ip4/0.0.0.0/tcp/5555"
+    datastore_dir: "/etc/routing/datastore"
+    directory_api_address: "mbta-ads-apiserver.mbta-ads.svc.cluster.local:8888"
+    gossipsub:
+      enabled: false
+  database:
+    type: "postgres"
+    postgres:
+      port: 5432
+      database: "dir"
+      ssl_mode: "disable"
+  store:
+    provider: "oci"
+    oci:
+      auth_config:
+        insecure: true
+  authn:
+    enabled: false
+  authz:
+    enabled: true
+    policy:
+      - "p,*,*"
+
+# Enable and customize these later if you adopt authenticated SPIRE-based federation.
+externalSecrets:
+  enabled: false

--- a/k8s/agntcy-dir-values.yaml
+++ b/k8s/agntcy-dir-values.yaml
@@ -1,0 +1,42 @@
+fullnameOverride: mbta-ads
+
+postgresql:
+  enabled: true
+  auth:
+    username: dir
+    password: dir
+    database: dir
+
+zot:
+  enabled: true
+
+# Development/demo-oriented values for the official AGNTCY Directory chart.
+# These defaults are intentionally insecure and should not be reused for production.
+config:
+  listen_address: "0.0.0.0:8888"
+  routing:
+    listen_address: "/ip4/0.0.0.0/tcp/5555"
+    datastore_dir: "/etc/routing/datastore"
+    directory_api_address: "mbta-ads-apiserver.mbta-ads.svc.cluster.local:8888"
+    gossipsub:
+      enabled: false
+  database:
+    type: "postgres"
+    postgres:
+      port: 5432
+      database: "dir"
+      ssl_mode: "disable"
+  store:
+    provider: "oci"
+    oci:
+      auth_config:
+        insecure: true
+  authn:
+    enabled: false
+  authz:
+    enabled: true
+    policy:
+      - "p,*,*"
+
+externalSecrets:
+  enabled: false

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -35,9 +35,17 @@ data:
   LOG_LEVEL: "INFO"
 
   # Registry federation (switchboard mode)
+  # Demo target topology:
+  #   - external MIT-NANDA -> mbta-stopfinder
+  #   - internal Northeastern NANDA -> mbta-alerts
+  #   - internal AGNTCY ADS -> mbta-planner
   ENABLE_FEDERATION: "false"
   SWITCHBOARD_TIMEOUT_SECONDS: "5"
+  # Official AGNTCY DIR/ADS exposes gRPC on port 8888. The current MBTA
+  # registry adapter still uses a legacy HTTP lookup path, so this setting is
+  # deployment-ready but will only become functional once the adapter is updated.
   AGNTCY_ADS_URL: ""
+  # Legacy adapter setting. Official DIR/ADS does not expose /v1/search.
   AGNTCY_ADS_SEARCH_PATH: "/v1/search"
   NEU_REGISTRY_URL: ""
 

--- a/k8s/k8_readme.md
+++ b/k8s/k8_readme.md
@@ -513,9 +513,9 @@ MbtaWinter2026/
 | `USE_SLIM` | Exchange | Enable SLIM transport (`true`/`false`) |
 | `REGISTRY_URL` | Exchange | NANDA registry endpoint |
 | `ENABLE_FEDERATION` | Registry | Enable switchboard-style federated lookups across registries |
-| `AGNTCY_ADS_URL` | Registry | AGNTCY ADS base URL used by the federation adapter |
-| `AGNTCY_ADS_SEARCH_PATH` | Registry | AGNTCY search path (default: `/v1/search`) |
-| `AGNTCY_ADS_TOKEN` | Registry (secret) | Optional bearer token for AGNTCY ADS |
+| `AGNTCY_ADS_URL` | Registry | Legacy AGNTCY adapter setting. Official DIR/ADS uses gRPC on `host:8888`, so this remains a placeholder until the adapter is updated |
+| `AGNTCY_ADS_SEARCH_PATH` | Registry | Legacy HTTP search path retained for compatibility with the current adapter; official DIR/ADS does not use `/v1/search` |
+| `AGNTCY_ADS_TOKEN` | Registry (secret) | Optional bearer token for internal or external AGNTCY ADS |
 | `NEU_REGISTRY_URL` | Registry | Northeastern registry base URL used by the federation adapter |
 | `ENABLE_EXTERNAL_REGISTRATION` | Register job | Mirror MBTA agent registrations to external registries |
 | `NEU_REGISTRY_REGISTER_URL` | Register job | External NEU register endpoint for mirroring |
@@ -613,6 +613,47 @@ python scripts/check_switchboard_diagnostics.py \
   --expect-neu reachable_found \
   --expect-agntcy reachable_found
 ```
+
+### Internal ADS Deployment Path
+
+The demo target topology places `mbta-planner` in internal AGNTCY ADS. The correct deployment path for that service is the official AGNTCY Directory Helm chart, not a hand-written Deployment manifest.
+
+For the April 10 demo, the intended operating mode is dev mode with SPIRE-based auth disabled. That keeps the install portable on LKE while preserving the option to add production-grade SPIRE mTLS later.
+
+To wire internal ADS into the Kubernetes deployment:
+
+1. Create `k8s/agntcy-dir-values.yaml` from [k8s/agntcy-dir-values.example.yaml](k8s/agntcy-dir-values.example.yaml).
+2. Export `DEPLOY_INTERNAL_AGNTCY_ADS=true` before running `bash deploy.sh apply`.
+3. Optionally export `AGNTCY_DIR_CHART_VERSION` if you need a version other than `v1.0.0`.
+4. Optionally export `AGNTCY_DIR_RELEASE_NAME=mbta-ads` and `AGNTCY_DIR_NAMESPACE=mbta-ads` if you need to override the demo defaults.
+5. Enable federation by setting `ENABLE_FEDERATION: "true"`.
+
+`deploy.sh apply` will automatically install the chart from `oci://ghcr.io/agntcy/dir/helm-charts/dir` when both conditions are true:
+
+- `DEPLOY_INTERNAL_AGNTCY_ADS=true`
+- `k8s/agntcy-dir-values.yaml` exists
+
+The official DIR/ADS service characteristics are:
+
+- gRPC API on port `8888`
+- libp2p routing/DHT on port `5555`
+- routing remains `ClusterIP`/internal-only for the demo; do not expose `5555` externally
+- no HTTP `/health` endpoint; use gRPC health probes
+- backing dependencies on Zot and PostgreSQL, both bundled by the Helm chart
+- demo auth stance is `authn.enabled: false` with `authz.enabled: true` and a permissive policy so the structure is in place for later tightening
+
+Current limitation: [src/registry/registry.py](src/registry/registry.py) still uses an HTTP-style AGNTCY adapter (`AGNTCY_ADS_URL` + `/v1/search`). This branch deploys the internal ADS infrastructure, but live MBTA registry lookups against official DIR/ADS still require a follow-up PR to switch the adapter to gRPC.
+
+Suggested operator checks for internal ADS:
+
+```bash
+kubectl -n mbta-ads get pods
+kubectl -n mbta-ads get svc
+kubectl -n mbta-ads port-forward svc/mbta-ads-apiserver 8888:8888
+grpcurl -plaintext localhost:8888 grpc.health.v1.Health/Check
+```
+
+If your Helm release name is not `mbta-ads`, adjust the `mbta-ads-apiserver` service name accordingly.
 
 ---
 

--- a/k8s/registry.yaml
+++ b/k8s/registry.yaml
@@ -56,6 +56,8 @@ spec:
                 configMapKeyRef:
                   name: mbta-config
                   key: SWITCHBOARD_TIMEOUT_SECONDS
+            # Internal or external AGNTCY ADS endpoint used by the
+            # switchboard adapter when federation is enabled.
             - name: AGNTCY_ADS_URL
               valueFrom:
                 configMapKeyRef:

--- a/k8s/secrets.example.yaml
+++ b/k8s/secrets.example.yaml
@@ -21,6 +21,6 @@ data:
   MBTA_API_KEY: REPLACE_WITH_BASE64_ENCODED_VALUE
   # echo -n "your-anthropic-api-key" | base64
   ANTHROPIC_API_KEY: REPLACE_WITH_BASE64_ENCODED_VALUE
-  # Optional: AGNTCY ADS bearer token for federated lookup
+  # Optional: AGNTCY ADS bearer token for internal or external federated lookup
   # echo -n "your-agntcy-ads-token" | base64
   AGNTCY_ADS_TOKEN: REPLACE_WITH_BASE64_ENCODED_VALUE


### PR DESCRIPTION
## Summary

This PR adds the first deployment milestone for internal AGNTCY ADS support in the MBTA demo environment.

It wires the official AGNTCY Directory Helm chart into the deploy flow, adds demo values files, and updates Kubernetes config and docs to match the April 10 demo plan: dev mode, `authn` disabled, permissive `authz`, release name `mbta-ads`, namespace `mbta-ads`, and no external exposure for routing port `5555`.

## Changes

- add optional internal ADS deployment support to `deploy.sh`
- add checked-in AGNTCY DIR demo values files
- update registry-related Kubernetes config comments for the intended demo topology
- document the internal ADS deployment path and basic operator checks

## Non-Goals

This PR does not implement live registry lookup against official AGNTCY DIR/ADS yet. The current registry adapter still uses the legacy HTTP-style AGNTCY integration and will need a follow-up PR for gRPC support.

This PR also does not add SPIRE, production auth, or external federation routing.

## Validation

Validated:
- deploy script syntax
- YAML structure for the new values files
- branch scope matches deployment/config/docs only

Not validated here:
- Helm install or template render, because Helm is not installed in this shell
- live Kubernetes deployment, because no reachable cluster is available from this shell
- end-to-end ADS lookups, because the gRPC adapter work is still pending

## Next Step

Follow up with a registry integration PR that replaces the current legacy AGNTCY HTTP adapter with official DIR/ADS gRPC calls.
