### PR TITLE
Add Kubernetes Ingress to expose stopfinder publicly

### DIFF
--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,65 @@
+# ============================================================
+# NGINX Ingress: Public subdomain routing for MBTA agents
+#
+# Prerequisites:
+#   - nginx ingress controller installed in the mbta namespace
+#   - DNS A records pointing *.agent.mitdataworksai.com to the
+#     nginx LoadBalancer IP
+#
+# Apply:
+#   kubectl apply -f k8s/ingress.yaml
+#
+# Verify:
+#   kubectl -n mbta get ingress
+#   curl https://stopfinder.agent.mitdataworksai.com/health
+# ============================================================
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mbta-agents-ingress
+  namespace: mbta
+  labels:
+    app.kubernetes.io/part-of: mbta-winter-2026
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+spec:
+  ingressClassName: nginx
+  rules:
+    # StopFinder Agent — registered in external MIT-NANDA registry
+    # Public endpoint required for federated discovery demo
+    - host: stopfinder.agent.mitdataworksai.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: stopfinder-agent
+                port:
+                  number: 8003
+
+    # Alerts Agent
+    - host: alerts.agent.mitdataworksai.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: alerts-agent
+                port:
+                  number: 8001
+
+    # Frontend Chat UI
+    - host: mbta.mitdataworksai.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 3000


### PR DESCRIPTION
## Summary

- Creates `k8s/ingress.yaml` with NGINX ingress rules exposing three subdomains:
  - `stopfinder.agent.mitdataworksai.com` → `stopfinder-agent:8003`
  - `alerts.agent.mitdataworksai.com` → `alerts-agent:8001`
  - `mbta.mitdataworksai.com` → `frontend:3000`

## Why

`mbta-stopfinder` needs a publicly reachable URL to be registered in the official MIT NANDA registry (issue #12). The service is currently ClusterIP-only — this ingress is the missing piece.

## Prerequisite before merging

A DNS `A` record must point `*.agent.mitdataworksai.com` to the nginx LoadBalancer IP. Pending answer from team on who controls the `mitdataworksai.com` domain.

## After merging

Keerthika can register `mbta-stopfinder` in MIT NANDA using `https://stopfinder.agent.mitdataworksai.com` as the endpoint, completing her side of issue #9.

## Related

- Closes #12 (once DNS is confirmed and registration is done)
- Unblocks Keerthika's registration tasks in #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)