### PR TITLE
Register mbta-stopfinder in MIT NANDA and enable federation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.enc.*.yaml
 secrets.yaml
 
+# Cluster credentials — never commit
+terraform/kubeconfig.yaml
+
 # Personal branch notes / blog drafts
 engineering_blog_entry_*.txt
 !blog/registration-readiness/

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -35,7 +35,7 @@ data:
   LOG_LEVEL: "INFO"
 
   # Registry federation (switchboard mode)
-  ENABLE_FEDERATION: "false"
+  ENABLE_FEDERATION: "true"
   SWITCHBOARD_TIMEOUT_SECONDS: "5"
   AGNTCY_ADS_URL: ""
   AGNTCY_ADS_SEARCH_PATH: "/v1/search"


### PR DESCRIPTION
## Summary

- Registers `mbta-stopfinder` in the official MIT NANDA registry at `https://nest.projectnanda.org` as `skill-mbta-stopfinder` with endpoint `https://stopfinder.agent.mitdataworksai.com`
- Sets `ENABLE_FEDERATION: "true"` in ConfigMap now that the public endpoint and registry record are confirmed live
- Adds `terraform/kubeconfig.yaml` to `.gitignore` to prevent cluster credentials from being committed

## Registration record

```
agent_id:  skill-mbta-stopfinder
endpoint:  https://stopfinder.agent.mitdataworksai.com
registry:  https://nest.projectnanda.org
record id: 69cfec50dd62feaea2da9f30
```

Verify: `curl https://nest.projectnanda.org/api/agents/skill-mbta-stopfinder`

## Test plan

- [x] `curl -sk https://stopfinder.agent.mitdataworksai.com/health` returns `{"ok":true,...}`
- [x] `curl https://nest.projectnanda.org/api/agents/skill-mbta-stopfinder` returns the registered record
- [ ] Apply updated configmap: `kubectl apply -f k8s/configmap.yaml`
- [ ] Restart exchange to pick up `ENABLE_FEDERATION=true`: `kubectl -n mbta rollout restart deployment/exchange`

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)